### PR TITLE
fix: frames are floats, not ints

### DIFF
--- a/mktoc/disc.py
+++ b/mktoc/disc.py
@@ -397,7 +397,7 @@ class _TrackTime(object):
       elif isinstance(arg,tuple):
          # assume arg is correct format
          self._time = arg
-      elif isinstance(arg,int):
+      elif isinstance(arg,float):
          # convert frame count to min,sec,frames
          min_,fr = divmod(arg, self._FPM)
          sec,fr = divmod(fr, self._FPS)


### PR DESCRIPTION
The frame number returned by `frames = w.getnframes() / (w.getframerate()/75)` is a float ending in .0, but the code only proceeds if it is an int. Presumably older versions of python didn't see a difference between 1.0 and 1, so the incorrect test went unnoticed.
In modern python versions, the elif is false and so we skip to the `else` and set the length as 00:00:00 for all tracks, leading to the "Track time calculation resulted in a negative value" error.

We could turn the float into an int, but I think this is just a waste of CPU cycles as divmod happily handles the float and returns the same TOC as the py2 version.